### PR TITLE
 QS tile titles visibility [2/2]

### DIFF
--- a/res/values/rr_strings.xml
+++ b/res/values/rr_strings.xml
@@ -2005,4 +2005,8 @@
     <string name="scroll_disclaimer_summary">Note: Most apps need to be restarted for custom values to take effect</string>
     <string name="animation_settings_reset_message">Reset all animation settings to default?</string>
 
+    <string name="qs_tile_title_visibility_title">QS tile titles</string>
+    <string name="qs_tile_title_visibility_summary_on">QS tiles titles are now visible</string>
+    <string name="qs_tile_title_visibility_summary_off">QS tiles titles are now gone</string>
+
 </resources>

--- a/res/xml/rr_qs_advanced.xml
+++ b/res/xml/rr_qs_advanced.xml
@@ -54,6 +54,7 @@
             android:key="music_tile_title"
             android:title="@string/qs_music_tile_track_optional_title"
             android:summary="@string/qs_music_tile_track_optional_summary"
+            android:dependency="qs_tile_title_visibility"
             android:defaultValue="false"/>
 
      	<com.android.settings.rr.Preferences.SecureSettingSwitchPreference
@@ -67,5 +68,12 @@
             android:title="@string/status_bar_battery_style_tile_title"
             android:summary="@string/status_bar_battery_style_tile_summary"
             android:defaultValue="true" />
+
+        <com.android.settings.rr.Preferences.SystemSettingSwitchPreference
+            android:key="qs_tile_title_visibility"
+            android:title="@string/qs_tile_title_visibility_title"
+            android:summaryOn="@string/qs_tile_title_visibility_summary_on"
+            android:summaryOff="@string/qs_tile_title_visibility_summary_off"
+            android:defaultValue="true"/>
 
 </PreferenceScreen>

--- a/res/xml/rr_qs_layout.xml
+++ b/res/xml/rr_qs_layout.xml
@@ -27,7 +27,7 @@
     <com.android.settings.rr.SeekBarPreference
         android:key="qs_layout_columns"
         android:title="@string/qs_columns_title"
-        settings:maximum="7"
+        settings:maximum="9"
         settings:minimum="1"
         settings:units=""
         android:persistent="false" />


### PR DESCRIPTION
- Increase the columns to 9
- Disable music tile title switch if this is enabled, no need for it

Signed-off-by: Varun Date <date.varun123@gmail.com>